### PR TITLE
Check for torch before touching it.

### DIFF
--- a/CameraWithAVFoundation/CustomizableCamera/Model Classes/CaptureSessionManager.m
+++ b/CameraWithAVFoundation/CustomizableCamera/Model Classes/CaptureSessionManager.m
@@ -107,9 +107,12 @@
     
     //Turn off the flash if on
     AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
-    [device lockForConfiguration:nil];
-    [device setTorchMode:AVCaptureTorchModeOff];
-    [device unlockForConfiguration];
+    if ([device hasTorch])
+    {
+        [device lockForConfiguration:nil];
+        [device setTorchMode:AVCaptureTorchModeOff];
+        [device unlockForConfiguration];
+    }
 }
 
 - (void)setEnableTorch:(BOOL)enableTorch


### PR DESCRIPTION
This fixes a crash on devices that have no torch.